### PR TITLE
fixed handling of pending job arrays in salljobs

### DIFF
--- a/salljobs/salljobs
+++ b/salljobs/salljobs
@@ -1,9 +1,5 @@
 #!/usr/bin/python
 
-"""
-salljobs - Return resource usage for all users.
-"""
-
 import sys
 from collections import defaultdict
 from pwd import getpwnam, getpwuid
@@ -15,13 +11,16 @@ try:
 except ImportError:
     sys.exit("You need to install PySlurm: https://github.com/PySlurm/pyslurm")
 
+__author__ = "Giovanni Torres"
+__date__ = "Fri Aug 21 12:59:28 EST 2015"
+
 # Print formatting for -u (by user)
-HEADER_FORMAT = "{0:>39}{1:>22}"
-LINE_FORMAT = "{0:>20}{1:>7}{2:>6}{3:>6}{4:>10}{5:>6}{6:>6}"
+HEADER_FORMAT = "                     {0:^23}    {1:^15}"
+LINE_FORMAT = "{0:>20} {1:>7} {2:>7} {3:>7}    {4:>7} {5:>7}"
 
 # Print formatting for -p (by partition)
-LINE_FORMAT_P1 = "{0:<20}{1:>13}{2:>6}{3:>6}{4:>6}{5:>6}"
-LINE_FORMAT_P2 = "{0:>33}{1:>6}{2:>6}{3:>6}{4:>6}"
+LINE_FORMAT_P1 = "{0:<20} {1:>13} {2:>7} {3:>7} {4:>7} {5:>7}"
+LINE_FORMAT_P2 = "{0:>34} {1:>7} {2:>7} {3:>7} {4:>7}"
 
 # SLURM job states
 STATES = {"PENDING": "PD",          # queued, waiting for initiation
@@ -38,38 +37,54 @@ STATES = {"PENDING": "PD",          # queued, waiting for initiation
           "SPECIAL_EXIT": "SE"}     # requeue an exit job in hold
 
 def sum_pending(array_tasks):
-    """Return sum of nodelist for pending jobs.  E.g. [0-10] = 11 nodes"""
-    if not "-" in array_tasks:
-        return 1
-    else:
-        if "%" in array_tasks:
-            pos = array_tasks.index("%")
-            array_tasks = array_tasks[:pos]
-        start, end = array_tasks.split("-")
-        return int(end) - int(start) + 1
-
+    """
+    Return number of subjobs for pending job array. This notation
+    can be pretty involved:
+          31392108_[1,3,5]
+          31392313_[1,3,5%2]
+          31392415_[1-5]
+    """
+    # remove a possible '%...' part
+    subjobstr = array_tasks.split("%")[0]
+    # split into chunks
+    chunks = subjobstr.split(",")
+    n = 0
+    for chunk in chunks:
+        if "-" not in array_tasks:
+            n += 1
+        else:
+            start, end = chunk.split("-")
+            n += int(end) - int(start) + 1
+    return n
 
 def rehash_job_dict(jobs):
+    """
+    rehash job dict to be keyed by username
+    """
     new_dict = defaultdict(list)
     for key, value in jobs.items():
         user_id = value.get("user_id")
         user_name = getpwuid(user_id)[0]
         new_dict[user_name].append(value)
+
     return new_dict
 
 def display_by_user(userlist, all_nodes, all_jobs):
-    """Display a list of all jobs, by default, formatted by user with the -u
-       option.  The -u option can take a space separated list of one or more
-       users."""
+    """
+    Display a list of all jobs, by default, formatted by user with the -u
+    option.  The -u option can take a space separated list of one or more
+    users.
+    Pending jobs don't include NODES - it just doesn't really make sense
+    especially for jobs smaller than single nodes.
+    """
 
     print ""
-    print HEADER_FORMAT.format("RUNNING/USED", "PENDING/REQUESTED")
-    print HEADER_FORMAT.format("-" * 17, "-" * 17)
+    print HEADER_FORMAT.format("RUNNING", "PENDING")
+    print HEADER_FORMAT.format("-" * 23, "-" * 15)
     print LINE_FORMAT.format("USERNAME", "CPUS", "NODES", "JOBS",
-                             "CPUS", "NODES", "JOBS")
+                             "CPUS", "JOBS")
 
     total_procs_request = 0
-    total_nodes_request = 0
     total_procs_used = 0
     total_nodes_used = 0
     total_job_running = 0
@@ -80,12 +95,11 @@ def display_by_user(userlist, all_nodes, all_jobs):
     for user in sorted(userlist):
 
         try:
-            user_jobs = rehashed_jobs.get(user)
+            user_jobs = rehashed_jobs[user]
         except KeyError:
-            sys.exit("Username not found.")
+            continue
 
         procs_request = 0
-        nodes_request = 0
         procs_used = 0
         nodes_used = set()
         running = 0
@@ -95,24 +109,31 @@ def display_by_user(userlist, all_nodes, all_jobs):
             continue
 
         for job in user_jobs:
-            if job["job_state"] == "RUNNING":
+            if job["job_state"] == "PENDING":
+                # If a job is pending, get the total number of pending subjobs,
+                # instead of counting it as just a single pending job.  For
+                # example, a pending swarm could have a 100 pending subjobs
+                #
+                # also: pending jobs may request CPUs in any increment but
+                # slurm does necessarily allocate in single CPU increments. It
+                # may allocate CPU, core, socket, or whole node increments. Since
+                # the final allocated CPU number could vary for identical pending
+                # jobs (if the, for example, ended up on hyperthreading vs non-hyperthreading
+                # nodes.
+                if job.get("array_task_str") is not None:
+                    n = sum_pending(job["array_task_str"])
+                    pending += n
+                    procs_request += job["num_cpus"] * n
+                else:
+                    pending += 1
+                    procs_request += job["num_cpus"]
+            else:
                 running += 1
                 procs_used += job["num_cpus"]
                 nodes_alloc = job["cpus_allocated"].keys()
                 nodes_used.update(nodes_alloc)
-            elif job["job_state"] == "PENDING":
-                # If a job is pending, get the total number of pending subjobs,
-                # instead of counting it as just a single pending job.  For
-                # example, a pending swarm could have a 100 pending subjobs
-                if job.get("array_task_str") is not None:
-                    pending += sum_pending(job["array_task_str"])
-                else:
-                    pending += 1
-                procs_request += job["num_cpus"]
-                nodes_request += job["num_nodes"]
 
         total_procs_request += procs_request
-        total_nodes_request += nodes_request
         total_procs_used += procs_used
         total_job_running += running
         total_job_pending += pending
@@ -122,39 +143,46 @@ def display_by_user(userlist, all_nodes, all_jobs):
                                  len(nodes_used),
                                  running,
                                  procs_request,
-                                 nodes_request,
                                  pending)
 
     # If one or more users are not specified, print a TOTAL summary
     if not args.user:
         used_nodes = get_used_nodes(all_nodes)
-        total_cpus = get_total_cpus(all_nodes)
+        total_cpus, total_nodes = get_total_cpus_and_nodes(all_nodes)
 
-        print HEADER_FORMAT.format("-" * 17, "-" * 17)
+        print HEADER_FORMAT.format("-" * 23, "-" * 15)
         print LINE_FORMAT.format("TOTAL",
                                  str(total_procs_used),
                                  str(used_nodes),
                                  total_job_running,
                                  total_procs_request,
-                                 total_nodes_request,
                                  total_job_pending)
+
 
         print LINE_FORMAT.format("AVAILABLE",
                                  str(total_cpus),
-                                 str(len(nodes)), "", "", "", "")
-        print ""
+                                 str(total_nodes), "", "", "", "")
+    pending_cpu_note()
+    print ""
+
+def pending_cpu_note():
+    print ""
+    print "The number of CPUs for PENDING jobs is a minimal estimate."
+    print "Actual allocation may be different."
 
 
 def display_by_partition(jobs, partlist, userlist):
-    """Display a list of all jobs formatted by partition with the -p
-       option.  The -p option can take a space separated list of one or more
-       users."""
+    """
+    Display a list of all jobs formatted by partition with the -p
+    option.  The -p option can take a space separated list of one or more
+    partitions.
+    """
 
     if userlist is None:
         # If users are not specified at the command line with the -p option,
         # get all users
         userset = set(value["user_id"]
-                      for value in jobs.itervalues())
+                      for value in jobs.values())
         users = [getpwuid(user)[0] for user in userset]
     else:
         users = userlist
@@ -196,33 +224,40 @@ def display_by_partition(jobs, partlist, userlist):
                     # instead of counting it as just a single pending job.  For
                     # example, a pending swarm could have a 100 pending subjobs
                     if job.get("array_task_str") is not None:
-                        user_totals[partition][job_state]["jobs"] += sum_pending(job["array_task_str"])
+                        n = sum_pending(job["array_task_str"])
+                        user_totals[partition][job_state]["jobs"] += n
+                        user_totals[partition][job_state]["cpus"] += cpus * n
                     else:
                         user_totals[partition][job_state]["jobs"] += 1
+                        user_totals[partition][job_state]["cpus"] += cpus
                 else:
                     user_totals[partition][job_state]["jobs"] += 1
-
-                user_totals[partition][job_state]["cpus"] += cpus
+                    user_totals[partition][job_state]["cpus"] += cpus
 
         line_counter = 0
 
-        for part, states in sorted(user_totals.iteritems()):
-            for state, totals in reversed(sorted(states.iteritems())):
+        for part, states in sorted(user_totals.items()):
+            for state, totals in reversed(sorted(states.items())):
                 cluster_totals_bypart[part][state]["jobs"] += totals["jobs"]
                 cluster_totals_bypart[part][state]["cpus"] += totals["cpus"]
+
+                if state == "PENDING":
+                    nnodes = "N/A"
+                else:
+                    nnodes = len(nodes_used[part][state]["node_set"])
 
                 if line_counter == 0:
                     print LINE_FORMAT_P1.format(user,
                                                 part,
                                                 STATES[state],
                                                 totals["cpus"],
-                                                len(nodes_used[part][state]["node_set"]),
+                                                nnodes,
                                                 totals["jobs"])
                 else:
                     print LINE_FORMAT_P2.format(part,
                                                 STATES[state],
                                                 totals["cpus"],
-                                                len(nodes_used[part][state]["node_set"]),
+                                                nnodes,
                                                 totals["jobs"])
                 line_counter += 1
 
@@ -238,6 +273,8 @@ def display_by_partition(jobs, partlist, userlist):
             cluster_totals_bystate[c_state]["cpus"] += c_totals["cpus"]
             sum_nodes = len(total_nodes_used[c_part][c_state]["node_set"])
             cluster_totals_bystate[c_state]["sum_nodes"] += sum_nodes
+            if c_state == "PENDING":
+                sum_nodes = "N/A"
 
             if c_line_counter == 0:
                 print LINE_FORMAT_P2.format(c_part,
@@ -258,12 +295,17 @@ def display_by_partition(jobs, partlist, userlist):
 
     print LINE_FORMAT_P2.format("", "STATE", "CPUS", "NODES", "JOBS")
 
-    for cs_state, cs_values in reversed(sorted(cluster_totals_bystate.iteritems())):
+    for cs_state, cs_values in reversed(sorted(cluster_totals_bystate.items())):
+        if cs_state == "PENDING":
+            nnodes = "N/A"
+        else:
+            nnodes = cs_values["sum_nodes"]
         print LINE_FORMAT_P2.format("",
                                   STATES[cs_state],
                                   cs_values["cpus"],
-                                  cs_values["sum_nodes"],
+                                  nnodes,
                                   cs_values["jobs"])
+    pending_cpu_note()
 
 
 def get_used_nodes(nodelist):
@@ -274,18 +316,24 @@ def get_used_nodes(nodelist):
                 or values['state'] == "MIXED"])
 
 
-def get_total_cpus(nodelist):
-    """Return total number of available CPUs.  Those nodes in the Down and
-       Drain* states are not counted in the totals."""
-    return sum([values['cpus'] for values in nodelist.itervalues()
+def get_total_cpus_and_nodes(nodelist):
+    """
+    Return total number of available CPUs and nodes.
+    Those nodes in the Down and Drain* states are not counted
+    in the totals.
+    """
+    tmp = [values['cpus'] for values in nodelist.values()
                 if not any(_ in values["state"]
-                           for _ in ["DOWN", "DRAIN"])])
+                           for _ in ("DOWN", "DRAIN"))]
+    return sum(tmp), len(tmp)
 
 
 def check_users(users):
-    """Slurm reports numeric user ids.  This function checks to see if the user
-        is in /etc/passwd, i.e. a valid user.  If not, exit with unknown user
-        message."""
+    """
+    Slurm reports numeric user ids.  This function checks to see if the user
+    is in /etc/passwd, i.e. a valid user.  If not, exit with unknown user
+    message.
+    """
     for user in users:
         try:
             usertest = getpwnam(user)


### PR DESCRIPTION
pending job arrays reported
  - the CPU requested by one pending job
  - node numbers

While it is very difficult to predict the actual exact number of CPUs
that will be allocated for pending jobs due to (1) the allocation unit
[cpu, core, socket, node?] and (2) the configuration of the node the job
will be scheduled on [hyperthreading or not? cores-per-sockt?, ...],
the number for job arrays should at least be the sum of all requested
CPUs for the pending jobs in the array.

also, it doesn't make sense to report nodes for pending jobs. It is not
known ahead of time on how many nodes the jobs will end up on.

Also fixed a bug in calculating the total number of available nodes (now
considers down/drained nodes).

this fixes issue #2